### PR TITLE
feat(exams): Update exams subdirectory with new database schema

### DIFF
--- a/starterkits/saas/src/app/(app)/(user)/dashboard/exams/_components/colums-dropdown.tsx
+++ b/starterkits/saas/src/app/(app)/(user)/dashboard/exams/_components/colums-dropdown.tsx
@@ -15,78 +15,75 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { MoreHorizontalIcon } from "lucide-react";
-import { membersToOrganizationsRoleEnum } from "@/server/db/schema";
 import { toast } from "sonner";
 import { type ExamsData } from "./colums";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import {
-    removeUserMutation,
-    updateMemberRoleMutation,
-} from "@/server/actions/organization/mutations";
+    deleteExam,
+    updateExam,
+} from "@/server/actions/exams/mutations";
 import { useAwaitableTransition } from "@/hooks/use-awaitable-transition";
 
-type Role = (typeof membersToOrganizationsRoleEnum.enumValues)[number];
-
-export function ColumnDropdown({ role, memberId }: ExamsData) {
+export function ColumnDropdown({ examId, title }: ExamsData) {
     const router = useRouter();
 
-    const { mutateAsync: changeRoleMutate, isPending: changeRoleIsPending } =
+    const { mutateAsync: updateExamMutate, isPending: updateExamIsPending } =
         useMutation({
-            mutationFn: ({ role }: { role: Role }) => {
-                return updateMemberRoleMutation({ memberId, role });
+            mutationFn: ({ title }: { title: string }) => {
+                return updateExam({ examId, title });
             },
             onSettled: () => {
                 router.refresh();
             },
         });
 
-    const [roleChangeIsTransitionPending, startAwaitableRoleChangeTransition] =
+    const [updateIsTransitionPending, startAwaitableUpdateTransition] =
         useAwaitableTransition();
 
-    const onRoleChange = (role: Role) => {
+    const onUpdateExam = (title: string) => {
         toast.promise(
             async () => {
-                await changeRoleMutate({ role });
-                await startAwaitableRoleChangeTransition(() => {
+                await updateExamMutate({ title });
+                await startAwaitableUpdateTransition(() => {
                     router.refresh();
                 });
             },
             {
-                loading: "Updating user role...",
-                success: "User role updated!",
-                error: "Failed to update user role, Check your permissions.",
+                loading: "Updating exam...",
+                success: "Exam updated!",
+                error: "Failed to update exam.",
             },
         );
     };
 
     const {
-        mutateAsync: removeMemberMutate,
-        isPending: removeMemberIsPending,
+        mutateAsync: deleteExamMutate,
+        isPending: deleteExamIsPending,
     } = useMutation({
-        mutationFn: ({ memberId }: { memberId: string }) =>
-            removeUserMutation({ memberId }),
+        mutationFn: ({ examId }: { examId: string }) =>
+            deleteExam({ examId }),
     });
 
     const [
-        removeMemberIsTransitionPending,
-        startAwaitableRemoveMemberTransition,
+        deleteIsTransitionPending,
+        startAwaitableDeleteTransition,
     ] = useAwaitableTransition();
 
-    const onRemoveMember = async () => {
+    const onDeleteExam = async () => {
         toast.promise(
             async () => {
-                await removeMemberMutate({
-                    memberId,
+                await deleteExamMutate({
+                    examId,
                 });
-                await startAwaitableRemoveMemberTransition(() => {
+                await startAwaitableDeleteTransition(() => {
                     router.refresh();
                 });
             },
             {
-                loading: "Removing user...",
-                success: "User removed ",
-                error: "Failed to remove user.",
+                loading: "Deleting exam...",
+                success: "Exam deleted",
+                error: "Failed to delete exam.",
             },
         );
     };
@@ -104,41 +101,21 @@ export function ColumnDropdown({ role, memberId }: ExamsData) {
 
                 <DropdownMenuSeparator />
 
-                <DropdownMenuSub>
-                    <DropdownMenuSubTrigger>Edit role</DropdownMenuSubTrigger>
-                    <DropdownMenuSubContent>
-                        <DropdownMenuRadioGroup
-                            value={role}
-                            onValueChange={(r) => onRoleChange(r as Role)}
-                        >
-                            {membersToOrganizationsRoleEnum.enumValues.map(
-                                (currentRole) => (
-                                    <DropdownMenuRadioItem
-                                        key={currentRole}
-                                        value={currentRole}
-                                        disabled={
-                                            changeRoleIsPending ||
-                                            roleChangeIsTransitionPending
-                                        }
-                                    >
-                                        {currentRole}
-                                    </DropdownMenuRadioItem>
-                                ),
-                            )}
-                        </DropdownMenuRadioGroup>
-                    </DropdownMenuSubContent>
-                </DropdownMenuSub>
+                <DropdownMenuItem
+                    disabled={updateExamIsPending || updateIsTransitionPending}
+                    onClick={() => onUpdateExam(title)}
+                >
+                    Update
+                </DropdownMenuItem>
 
                 <DropdownMenuSeparator />
 
                 <DropdownMenuItem
-                    disabled={
-                        removeMemberIsPending || removeMemberIsTransitionPending
-                    }
-                    onClick={onRemoveMember}
+                    disabled={deleteExamIsPending || deleteIsTransitionPending}
+                    onClick={onDeleteExam}
                     className="text-red-600"
                 >
-                    Remove
+                    Delete
                 </DropdownMenuItem>
             </DropdownMenuContent>
         </DropdownMenu>

--- a/starterkits/saas/src/app/(app)/(user)/dashboard/exams/_components/colums.tsx
+++ b/starterkits/saas/src/app/(app)/(user)/dashboard/exams/_components/colums.tsx
@@ -3,7 +3,6 @@
 "use client";
 
 import { type ColumnDef } from "@tanstack/react-table";
-import { type membersToOrganizations } from "@/server/db/schema";
 import { Badge } from "@/components/ui/badge";
 import { ColumnDropdown } from "./colums-dropdown";
 import { format } from "date-fns";
@@ -11,12 +10,11 @@ import { format } from "date-fns";
 // This type is used to define the shape of our data.
 // You can use a Zod schema here if you want.
 export type ExamsData = {
-    id: string;
-    name: string | null;
-    email: string;
-    memberId: string;
-    role: typeof membersToOrganizations.$inferSelect.role;
+    examId: string;
+    title: string;
+    description: string;
     createdAt: Date;
+    updatedAt: Date;
 };
 
 export function getColumns(): ColumnDef<ExamsData>[] {
@@ -25,37 +23,14 @@ export function getColumns(): ColumnDef<ExamsData>[] {
 
 export const columns: ColumnDef<ExamsData>[] = [
     {
-        accessorKey: "name",
-        header: () => <span className="pl-2">Name</span>,
-        cell: ({ row }) => {
-            console.log(row.original);
-
-            if (row.original.name) {
-                return (
-                    <span className="pl-2 font-medium">
-                        {row.original.name}
-                    </span>
-                );
-            }
-
-            return <span className="pl-2 text-muted-foreground">No name</span>;
-        },
+        accessorKey: "title",
+        header: () => <span className="pl-2">Title</span>,
+        cell: ({ row }) => <span className="pl-2 font-medium">{row.original.title}</span>,
     },
     {
-        accessorKey: "email",
-        header: "Email",
-    },
-    {
-        accessorKey: "role",
-        header: "Role",
-        cell: ({ row }) => (
-            <Badge variant="secondary" className="capitalize">
-                {row.original.role}
-            </Badge>
-        ),
-        filterFn: (row, id, value) => {
-            return !!value.includes(row.getValue(id));
-        },
+        accessorKey: "description",
+        header: "Description",
+        cell: ({ row }) => <span className="pl-2">{row.original.description}</span>,
     },
     {
         accessorKey: "createdAt",
@@ -63,6 +38,15 @@ export const columns: ColumnDef<ExamsData>[] = [
         cell: ({ row }) => (
             <span className="text-muted-foreground">
                 {format(new Date(row.original.createdAt), "PP")}
+            </span>
+        ),
+    },
+    {
+        accessorKey: "updatedAt",
+        header: "Updated At",
+        cell: ({ row }) => (
+            <span className="text-muted-foreground">
+                {format(new Date(row.original.updatedAt), "PP")}
             </span>
         ),
     },

--- a/starterkits/saas/src/app/(app)/(user)/dashboard/exams/_components/exams-table.tsx
+++ b/starterkits/saas/src/app/(app)/(user)/dashboard/exams/_components/exams-table.tsx
@@ -4,67 +4,46 @@ import { DataTable } from "@/app/(app)/_components/data-table";
 import { type ColumnDef } from "@tanstack/react-table";
 import React, { useMemo } from "react";
 import { getColumns, type ExamsData } from "./colums";
-import { membersToOrganizationsRoleEnum } from "@/server/db/schema";
 import { useDataTable } from "@/hooks/use-data-table";
 import type {
     DataTableFilterableColumn,
     DataTableSearchableColumn,
 } from "@/types/data-table";
-import { type getPaginatedOrgMembersQuery } from "@/server/actions/organization/queries";
-
-/** @learn more about data-table at shadcn ui website @see https://ui.shadcn.com/docs/components/data-table */
+import { getAllExams } from "@/server/actions/exams/queries";
 
 const filterableColumns: DataTableFilterableColumn<ExamsData>[] = [
     {
         id: "role",
         title: "Role",
-        options: membersToOrganizationsRoleEnum.enumValues.map((v) => ({
-            label: v,
-            value: v,
-        })),
+        options: [
+            { label: "Invigilator", value: "Invigilator" },
+            { label: "Manager", value: "Manager" },
+            { label: "Billing", value: "Billing" },
+            { label: "Admin", value: "Admin" },
+        ],
     },
 ];
 
-type MembersTableProps = {
-    membersPromise: ReturnType<typeof getPaginatedOrgMembersQuery>;
-};
-
 const searchableColumns: DataTableSearchableColumn<ExamsData>[] = [
-    { id: "email", placeholder: "Search email..." },
+    { id: "title", placeholder: "Search title..." },
+    { id: "description", placeholder: "Search description..." },
 ];
 
-export function ExamsTable({ membersPromise }: MembersTableProps) {
-    const { data, pageCount, total } = React.use(membersPromise);
+export function ExamsTable() {
+    const examsPromise = React.useMemo(() => getAllExams(), []);
 
-    const columns = useMemo<ColumnDef<ExamsData, unknown>[]>(
-        () => getColumns(),
-        [],
-    );
-
-    const ExamsData: ExamsData[] = data.map((member) => {
-        return {
-            id: member.id!,
-            role: member.role,
-            createdAt: member.createdAt,
-            email: member.member.email,
-            name: member.member.name,
-            memberId: member.memberId,
-        };
-    });
-
-    const { table } = useDataTable({
-        data: ExamsData,
-        columns,
-        pageCount,
-        searchableColumns,
+    const { data, pageCount, total } = useDataTable({
+        dataPromise: examsPromise,
+        columns: useMemo<ColumnDef<ExamsData, unknown>[]>(() => getColumns(), []),
         filterableColumns,
+        searchableColumns,
     });
 
     return (
         <>
             <DataTable
-                table={table}
-                columns={columns}
+                table={data}
+                columns={useMemo<ColumnDef<ExamsData, unknown>[]>(() => getColumns(), [])}
                 filterableColumns={filterableColumns}
                 searchableColumns={searchableColumns}
                 totalRows={total}

--- a/starterkits/saas/src/server/actions/exams/mutations.ts
+++ b/starterkits/saas/src/server/actions/exams/mutations.ts
@@ -1,0 +1,24 @@
+import { db } from '../../db';
+import { exams } from '../../db/schema';
+import { sql } from 'drizzle-orm';
+
+export async function createExam({ title, description }) {
+  return db.insertInto(exams).values({
+    title,
+    description,
+    createdAt: sql`CURRENT_TIMESTAMP`,
+    updatedAt: sql`CURRENT_TIMESTAMP`,
+  }).returningAll().executeTakeFirstOrThrow();
+}
+
+export async function updateExam({ examId, title, description }) {
+  return db.update(exams).set({
+    title,
+    description,
+    updatedAt: sql`CURRENT_TIMESTAMP`,
+  }).where(exams.examId.eq(examId)).returningAll().executeTakeFirstOrThrow();
+}
+
+export async function deleteExam({ examId }) {
+  return db.deleteFrom(exams).where(exams.examId.eq(examId)).executeTakeFirstOrThrow();
+}

--- a/starterkits/saas/src/server/actions/exams/queries.ts
+++ b/starterkits/saas/src/server/actions/exams/queries.ts
@@ -1,0 +1,15 @@
+import { db } from '../../db';
+import { exams } from '../../db/schema';
+
+export async function getExamById(examId: string) {
+  return db.selectFrom(exams)
+    .selectAll()
+    .where(exams.examId.eq(examId))
+    .executeTakeFirstOrThrow();
+}
+
+export async function getAllExams() {
+  return db.selectFrom(exams)
+    .selectAll()
+    .execute();
+}

--- a/starterkits/saas/src/server/db/schema.ts
+++ b/starterkits/saas/src/server/db/schema.ts
@@ -347,3 +347,15 @@ export const waitlistUsersSchema = createInsertSchema(waitlistUsers, {
     email: z.string().email("Email must be a valid email address"),
     name: z.string().min(3, "Name must be at least 3 characters long"),
 });
+
+// Adding new table definition for exams
+export const exams = createTable("exams", {
+    examId: varchar("examId", { length: 255 })
+        .notNull()
+        .primaryKey()
+        .default(sql`gen_random_uuid()`),
+    title: varchar("title", { length: 255 }).notNull(),
+    description: text("description").notNull(),
+    createdAt: timestamp("createdAt", { mode: "date" }).notNull().defaultNow(),
+    updatedAt: timestamp("updatedAt", { mode: "date" }).notNull().defaultNow(),
+});


### PR DESCRIPTION
This pull request introduces updates to the `exams` subdirectory to align with the new database schema for exams, including the necessary mutations and queries for managing exams data.

- **Database Schema Update**: Adds a new table definition for `exams` in `starterkits/saas/src/server/db/schema.ts`, including fields such as `examId`, `title`, `description`, `createdAt`, and `updatedAt`.
- **Mutations and Queries Implementation**: Implements CRUD operations for exams in `starterkits/saas/src/server/actions/exams/mutations.ts` and `starterkits/saas/src/server/actions/exams/queries.ts`. This includes functions to create, update, delete, and fetch exam details.
- **Frontend Integration**: Updates components within the `exams` subdirectory to utilize the new mutations and queries. This includes changes to `colums-dropdown.tsx`, `colums.tsx`, and `exams-table.tsx` to reflect the new `exams` schema fields and to use the newly implemented CRUD operations for exams.